### PR TITLE
name the button correctly, allow to choose from ISP or PLAY button

### DIFF
--- a/main.c
+++ b/main.c
@@ -43,7 +43,10 @@
 
 #include "lpc17xx_wdt.h"
 
-#define ISP_BTN	P2_12
+#define PLAY_BTN    P2_12
+#define ISP_BTN	    P2_10
+
+#define DFU_BTN     PLAY_BTN
 
 #ifndef DEBUG_MESSAGES
 #define printf(...) do {} while (0)
@@ -64,9 +67,9 @@ void setleds(int leds)
 	GPIO_write(LED5, leds & 16);
 }
 
-int isp_btn_pressed(void)
+int dfu_btn_pressed(void)
 {
-	return GPIO_get(ISP_BTN);
+	return GPIO_get(DFU_BTN);
 }
 
 void start_dfu(void)
@@ -182,7 +185,7 @@ int main(void)
 {
 	WDT_Feed();
 
-	GPIO_init(ISP_BTN); GPIO_input(ISP_BTN);
+	GPIO_init(DFU_BTN); GPIO_input(DFU_BTN);
 
 	GPIO_init(LED1); GPIO_output(LED1);
 	GPIO_init(LED2); GPIO_output(LED2);
@@ -210,7 +213,7 @@ int main(void)
 		check_sd_firmware();
 
 	int dfu = 0;
-	if (isp_btn_pressed() == 0)
+	if (dfu_btn_pressed() == 0)
 	{
 		printf("ISP button pressed, entering DFU mode\n");
 		dfu = 1;


### PR DESCRIPTION
It's a minor thing, but it cost me some time (I never used this mode, because it never worked and sdcard method did, but now I have to).
So I want to change this, in case someone else might get into the same trouble.

If I don't miss something the button to jump into dfu mode was changed without renaming the name in main.c.
This PR fixes the name to say what it does and allows to choose between ISP and PLAY button, which both works.

Note, I have an early Smoothieboard v1.0 (the one with A498x drivers) so I am not totally sure if it has a different pinout, but these pages at least show the same pins for those buttons:
http://smoothieware.org/smoothieboard-v1-old
http://smoothieware.org/pinout
